### PR TITLE
162 missing nodes in call graph

### DIFF
--- a/mole/controllers/path.py
+++ b/mole/controllers/path.py
@@ -412,7 +412,7 @@ class PathController:
                             if not path:
                                 continue
                             # Serialize and dump path
-                            s_path = path.to_dict()
+                            s_path = path.to_dict(debug=True)
                             if i != 0:
                                 f.write(",\n")
                             f.write(" " * ident)

--- a/mole/core/slice.py
+++ b/mole/core/slice.py
@@ -107,14 +107,20 @@ class MediumLevelILFunctionGraph(nx.DiGraph):
         graph.update(self)
         return graph
 
-    def to_dict(self) -> Dict:
+    def to_dict(self, debug: bool = False) -> Dict:
         """
         This method serializes the graph to a dictionary.
         """
         # Serialize nodes
         nodes: List[Dict[str, Any]] = []
         for node, atts in self.nodes(data=True):
-            nodes.append({"adr": hex(node.source_function.start), "att": atts})
+            node_dict = {
+                "adr": hex(node.source_function.start),
+                "att": atts,
+            }
+            if debug:
+                node_dict["func"] = FunctionHelper.get_func_info(node, True)
+            nodes.append(node_dict)
         # Serialize edges
         edges: List[Dict[str, Any]] = []
         for src_node, tgt_node, atts in self.edges(data=True):

--- a/mole/core/slice.py
+++ b/mole/core/slice.py
@@ -512,6 +512,7 @@ class MediumLevelILBackwardSlicer:
             ):
                 call_info = InstructionHelper.get_inst_info(inst, False)
                 dest_info = InstructionHelper.get_inst_info(dest_inst)
+
                 match dest_inst:
                     # Direct function calls
                     case (
@@ -527,6 +528,7 @@ class MediumLevelILBackwardSlicer:
                         else:
                             func = func.mlil.ssa_form
                             symb = func.source_function.symbol
+
                             for func_inst in func.instructions:
                                 # TODO: Support all return instructions
                                 match func_inst:


### PR DESCRIPTION
- Use merged call graph (call graph of source function was missing)
- Include additional debug information in exported paths (breaks backward compatibility)