### PR TITLE
169 improve OpenAI api compatibility by removing streaming

### DIFF
--- a/mole/models/ai.py
+++ b/mole/models/ai.py
@@ -109,6 +109,7 @@ class ToolFunction:
     description: str
     parameters: List[ToolParameter]
     required: List[str]
+    strict: bool
     handler: Optional[Callable[..., Any]] = None
 
     def to_dict(self) -> Dict:
@@ -131,6 +132,7 @@ class ToolFunction:
                     "properties": properties,
                     "required": self.required,
                 },
+                "strict": self.strict,
             },
         }
 
@@ -153,6 +155,7 @@ tools: Dict[str, ToolFunction] = {
             ),
         ],
         required=["addr", "il_type"],
+        strict=True,
         handler=get_code_for_functions_containing,
     ),
     "get_code_for_functions_by_name": ToolFunction(
@@ -172,6 +175,7 @@ tools: Dict[str, ToolFunction] = {
             ),
         ],
         required=["name", "il_type"],
+        strict=True,
         handler=get_code_for_functions_by_name,
     ),
     "get_callers_by_address": ToolFunction(
@@ -185,6 +189,7 @@ tools: Dict[str, ToolFunction] = {
             )
         ],
         required=["addr"],
+        strict=True,
         handler=get_callers_by_address,
     ),
     "get_callers_by_name": ToolFunction(
@@ -198,6 +203,7 @@ tools: Dict[str, ToolFunction] = {
             )
         ],
         required=["name"],
+        strict=True,
         handler=get_callers_by_name,
     ),
 }

--- a/mole/services/ai.py
+++ b/mole/services/ai.py
@@ -175,29 +175,14 @@ Be proactive in exploring upstream paths, analyzing data/control dependencies, a
         message = None
         try:
             # Send messages and receive completion message
-            completion = None
-            with client.beta.chat.completions.stream(
+            completion = client.beta.chat.completions.parse(
                 messages=messages,
                 model=self._model,
                 tools=self._tools,
                 max_completion_tokens=self._max_completion_tokens,
                 temperature=self._temperature,
                 response_format=VulnerabilityReport,
-                stream_options={"include_usage": True},
-            ) as stream:
-                for chunk_cnt, _ in enumerate(stream):
-                    if self.cancelled:
-                        log.warn(
-                            custom_tag,
-                            f"Cancel message streaming after {chunk_cnt:d} chunks",
-                        )
-                        return None
-                    chunk_cnt += 1
-                log.debug(
-                    custom_tag,
-                    f"Streaming messages finished after {chunk_cnt:d} chunks",
-                )
-                completion = stream.get_final_completion()
+            )
             message = completion.choices[0].message
             if completion.usage:
                 token_usage["prompt_tokens"] += completion.usage.prompt_tokens


### PR DESCRIPTION
I had to add the `strict` field to allow auto-parsing (use of the `.parse()` api) and avoid such error
```[Mole.AI] [Path:2] Failed to send messages: `get_code_for_functions_containing` is not strict. Only `strict` function tools can be auto-parsed```
