### PR TITLE
Ignore actual calls are not in the slice

### DIFF
--- a/mole/core/slice.py
+++ b/mole/core/slice.py
@@ -282,7 +282,11 @@ class MediumLevelILBackwardSlicer:
                     call_parm = call_inst.params[parm_idx]
                     # Visit specific caller site if we go up the call stack (all caller sites otherwise)
                     if caller_level is not None and caller_level <= call_level:
+                        # Ignore if the actual call instruction is not within the caller site
                         if caller_site != call_inst.function:
+                            continue
+                        # Ignore if the actual call instruction was not sliced before
+                        if call_inst not in self.inst_graph:
                             continue
                     var_info = VariableHelper.get_ssavar_info(ssa_var)
                     call_info = InstructionHelper.get_inst_info(call_inst, False)

--- a/test/test_slicing.py
+++ b/test/test_slicing.py
@@ -866,7 +866,7 @@ class TestPointerAnalysis(TestCase):
             # Analyze test binary
             paths = self.get_paths(bv)
             # Assert results
-            self.assertEqual(len(paths), 12, "12 paths identified")
+            self.assertEqual(len(paths), 6, "6 paths identified")
             for path in paths:
                 self.assertEqual(
                     path.src_sym_name, "getenv", "source has symbol 'getenv'"


### PR DESCRIPTION
We now additionally validate that the actual call instruction we want to go back, is part of the slice. This solves the current issue, does not remove any correct paths but might not be perfect in all cases (we might still have some unwanted paths).