### PR TITLE
Fix: update address comparison in SinkFunction to ensure accuracy

### DIFF
--- a/mole/core/data.py
+++ b/mole/core/data.py
@@ -562,7 +562,7 @@ class SinkFunction(Function):
                                     for src_inst in src_inst_graph.nodes():
                                         # Ignore source instructions that were not sliced in the sink
                                         if not any(
-                                            inst[1].address == src_inst[1].address
+                                            inst[1] == src_inst[1]
                                             for inst in snk_inst_graph
                                         ):
                                             continue
@@ -580,7 +580,7 @@ class SinkFunction(Function):
                                         _src_insts = [
                                             inst
                                             for inst in snk_inst_graph
-                                            if inst[1] and inst[1].address == src_inst[1].address
+                                            if inst[1] and inst[1] == src_inst[1]
                                         ]
                                         for _src_inst in _src_insts:
                                             try:

--- a/test/src/strcpy-01.c
+++ b/test/src/strcpy-01.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/*
+Testcase Description:
+- getopt param ended up in a strcpy call
+*/
+
+int main(int argc, char *argv[]) {
+    char buffer[128];
+    int opt;
+    char *source = NULL;
+
+    while ((opt = getopt(argc, argv, "s:")) != -1) {
+        switch (opt) {
+            case 's':
+                source = optarg;
+                break;
+            default:
+                return EXIT_FAILURE;
+        }
+    }
+
+    if (source != NULL) {
+        // User-controlled source from getopt ends up in memcpy
+        strcpy(buffer, source);
+        printf("Copied: %s\n", buffer);
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
While analyzing a new firmware, I encountered an unusual scenario where a complex phi instruction didn’t match when performing a typical `inst == inst` comparison. Interestingly, comparing the addresses works as expected and should also speed up the comparison, as it avoids hashing multiple fields of the object. I wasn’t able to come up with a unit test to reproduce this behavior, though.