### PR TITLE
Increase Minimum Binja Version from 6455 to 7290

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -26,5 +26,5 @@
   },
   "version": "0.5.1",
   "author": "Damian Pfammatter and Sergio Paganoni",
-  "minimumbinaryninjaversion": 6455
+  "minimumbinaryninjaversion": 7290
 }


### PR DESCRIPTION
We now require at least `5.X`.