### PR TITLE
267 slicer should follow alternative memory definitions during phi node resolution

### DIFF
--- a/mole/core/slice.py
+++ b/mole/core/slice.py
@@ -220,10 +220,40 @@ class MediumLevelILBackwardSlicer:
             inst.function, inst.ssa_memory_version, self._max_memory_slice_depth
         )
         # Iterate memory defining instructions
-        for mem_def_inst in mem_def_insts:
-            followed = self._slice_ssa_var_mem_definition(ssa_var, inst, mem_def_inst)
-            if followed:
-                break
+        i = 0
+        while i < len(mem_def_insts):
+            mem_def_inst = mem_def_insts[i]
+            match mem_def_inst:
+                # If the memory can be defined by multiple instructions (mem phi-node), try to following all of them
+                case bn.MediumLevelILMemPhi(src_memory=src_memory_versions):
+                    processed_cnt = 0
+                    for j, src_memory_version in enumerate(
+                        src_memory_versions, start=1
+                    ):
+                        if i + j >= len(mem_def_insts):
+                            break
+                        if (
+                            mem_def_insts[i + j].ssa_memory_version_after
+                            != src_memory_version
+                        ):
+                            break
+                        if self._slice_ssa_var_mem_definition(
+                            ssa_var, inst, mem_def_insts[i + j]
+                        ):
+                            followed = True
+                        processed_cnt += 1
+                    if followed:
+                        break
+                    else:
+                        i += processed_cnt
+                # Try to follow the memory defining instruction
+                case _:
+                    followed = self._slice_ssa_var_mem_definition(
+                        ssa_var, inst, mem_def_inst
+                    )
+                    if followed:
+                        break
+            i += 1
         return followed
 
     def _slice_ssa_var_definition(

--- a/plugin.json
+++ b/plugin.json
@@ -24,7 +24,7 @@
     "Linux": "",
     "Windows": ""
   },
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": "Damian Pfammatter and Sergio Paganoni",
   "minimumbinaryninjaversion": 7290
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mole"
-version = "0.7.1"
+version = "0.7.2"
 description = "A Binary Ninja plugin to identify interesting paths using static backward slicing"
 authors = [
     {name = "Damian Pfammatter"},

--- a/tests/data/src/mem_phi-01.c
+++ b/tests/data/src/mem_phi-01.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define BUF_SIZE 64
+
+/*
+Testcase Description:
+- Memory defined by multiple instructions (mem phi-node)
+*/
+
+int main(int argc, char *argv[]) {
+    char *env_dst;
+    char cmd[BUF_SIZE];
+
+    env_dst = getenv("DESTINATION");
+    if(env_dst == NULL) {
+        strcpy(cmd, "ping -c 1 127.0.0.1 &");
+    } else {
+        snprintf(cmd, BUF_SIZE, "ping -c 1 \"%s\" &", env_dst);
+    }
+    system(cmd);
+    return EXIT_SUCCESS;
+}

--- a/tests/slicing/test_various.py
+++ b/tests/slicing/test_various.py
@@ -107,3 +107,12 @@ class TestVarious(TestSlicing):
     def test_memcpy_11(self, filenames: List[str] = ["memcpy-11"]) -> None:
         self.test_memcpy_06(filenames)
         return
+
+    def test_mem_phi_01(self, filenames: List[str] = ["mem_phi-01"]) -> None:
+        self.assert_paths(
+            srcs=[("getenv", None)],
+            snks=[("system", 1)],
+            call_chains=[["main"]],
+            filenames=filenames,
+        )
+        return

--- a/uv.lock
+++ b/uv.lock
@@ -349,7 +349,7 @@ wheels = [
 
 [[package]]
 name = "mole"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "lark" },


### PR DESCRIPTION
Fixes issue #267 and adds a corresponding unit-test.